### PR TITLE
Overhaul of snapshot management

### DIFF
--- a/tunnelclient/Cargo.lock
+++ b/tunnelclient/Cargo.lock
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -222,6 +222,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -657,6 +666,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "glfw"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "919ebc7bdbf60a529689a5e58f80d9dcde27e3d2ab4f2f7ce711ec439fe789c5"
+dependencies = [
+ "bitflags",
+ "glfw-sys",
+ "objc",
+ "raw-window-handle",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "glfw-sys"
+version = "4.0.0+3.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5abed6d39a50226676aab893d6b4ad154da7e93fcdfed90d7696758a1b477ed1"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
 name = "glutin"
 version = "0.30.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +990,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1267,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
 name = "objc-sys"
 version = "0.2.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1531,19 @@ dependencies = [
  "pistoncore-input",
  "pistoncore-window",
  "spin_sleep",
+]
+
+[[package]]
+name = "pistoncore-glfw_window"
+version = "0.78.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbaf6f19f20117d35c12145046b38f1178d6bc355c4a63989a051ddafec543e"
+dependencies = [
+ "gl",
+ "glfw",
+ "pistoncore-input",
+ "pistoncore-window",
+ "shader_version",
 ]
 
 [[package]]
@@ -2279,6 +2341,7 @@ dependencies = [
  "piston2d-graphics",
  "piston2d-opengl_graphics",
  "piston_window",
+ "pistoncore-glfw_window",
  "pistoncore-glutin_window",
  "pistoncore-sdl2_window",
  "regex",

--- a/tunnelclient/Cargo.lock
+++ b/tunnelclient/Cargo.lock
@@ -225,15 +225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,28 +657,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glfw"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919ebc7bdbf60a529689a5e58f80d9dcde27e3d2ab4f2f7ce711ec439fe789c5"
-dependencies = [
- "bitflags",
- "glfw-sys",
- "objc",
- "raw-window-handle",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "glfw-sys"
-version = "4.0.0+3.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5abed6d39a50226676aab893d6b4ad154da7e93fcdfed90d7696758a1b477ed1"
-dependencies = [
- "cmake",
-]
-
-[[package]]
 name = "glutin"
 version = "0.30.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,15 +959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,15 +1227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
 name = "objc-sys"
 version = "0.2.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,19 +1482,6 @@ dependencies = [
  "pistoncore-input",
  "pistoncore-window",
  "spin_sleep",
-]
-
-[[package]]
-name = "pistoncore-glfw_window"
-version = "0.78.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbaf6f19f20117d35c12145046b38f1178d6bc355c4a63989a051ddafec543e"
-dependencies = [
- "gl",
- "glfw",
- "pistoncore-input",
- "pistoncore-window",
- "shader_version",
 ]
 
 [[package]]
@@ -2341,7 +2279,6 @@ dependencies = [
  "piston2d-graphics",
  "piston2d-opengl_graphics",
  "piston_window",
- "pistoncore-glfw_window",
  "pistoncore-glutin_window",
  "pistoncore-sdl2_window",
  "regex",

--- a/tunnelclient/Cargo.toml
+++ b/tunnelclient/Cargo.toml
@@ -30,7 +30,6 @@ derive_more = "0.99"
 log = "0.4"
 simplelog = "0.12.0"
 anyhow = "1.0.70"
-pistoncore-glfw_window = "0.78.0"
 
 [dependencies.pistoncore-sdl2_window]
 git = "https://github.com/PistonDevelopers/sdl2_window"

--- a/tunnelclient/Cargo.toml
+++ b/tunnelclient/Cargo.toml
@@ -30,6 +30,7 @@ derive_more = "0.99"
 log = "0.4"
 simplelog = "0.12.0"
 anyhow = "1.0.70"
+pistoncore-glfw_window = "0.78.0"
 
 [dependencies.pistoncore-sdl2_window]
 git = "https://github.com/PistonDevelopers/sdl2_window"

--- a/tunnelclient/cfg/monitor.yaml
+++ b/tunnelclient/cfg/monitor.yaml
@@ -1,11 +1,12 @@
 server_hostname: "127.0.0.1"
-render_delay: 0.004
+render_delay: 0.1
 timesync_interval: 60000
-x_resolution: 700
-y_resolution: 525
+x_resolution: 1920
+y_resolution: 1080
 flip_horizontal: false
 anti_alias: true
-fullscreen: false
+fullscreen: true
 capture_mouse: false
 alpha_blend: true
 log_level_debug: false
+use_single_snapshot: false

--- a/tunnelclient/cfg/monitor.yaml
+++ b/tunnelclient/cfg/monitor.yaml
@@ -4,9 +4,7 @@ timesync_interval: 60000
 x_resolution: 700
 y_resolution: 525
 flip_horizontal: false
-anti_alias: true
 fullscreen: false
 capture_mouse: false
-alpha_blend: true
 log_level_debug: false
 use_single_snapshot: true

--- a/tunnelclient/cfg/monitor.yaml
+++ b/tunnelclient/cfg/monitor.yaml
@@ -1,12 +1,12 @@
 server_hostname: "127.0.0.1"
-render_delay: 0.1
+render_delay: 0.020
 timesync_interval: 60000
-x_resolution: 1920
-y_resolution: 1080
+x_resolution: 700
+y_resolution: 525
 flip_horizontal: false
 anti_alias: true
 fullscreen: true
 capture_mouse: false
 alpha_blend: true
 log_level_debug: false
-use_single_snapshot: false
+use_single_snapshot: true

--- a/tunnelclient/cfg/monitor.yaml
+++ b/tunnelclient/cfg/monitor.yaml
@@ -5,7 +5,7 @@ x_resolution: 700
 y_resolution: 525
 flip_horizontal: false
 anti_alias: true
-fullscreen: true
+fullscreen: false
 capture_mouse: false
 alpha_blend: true
 log_level_debug: false

--- a/tunnelclient/cfg/monitor_1080.yaml
+++ b/tunnelclient/cfg/monitor_1080.yaml
@@ -1,5 +1,5 @@
 server_hostname: "127.0.0.1"
-render_delay: 0.015
+render_delay: 0.020
 timesync_interval: 60000
 x_resolution: 1920
 y_resolution: 1080
@@ -9,3 +9,4 @@ fullscreen: false
 capture_mouse: false
 alpha_blend: true
 log_level_debug: false
+use_single_snapshot: true

--- a/tunnelclient/cfg/monitor_1080.yaml
+++ b/tunnelclient/cfg/monitor_1080.yaml
@@ -4,9 +4,7 @@ timesync_interval: 60000
 x_resolution: 1920
 y_resolution: 1080
 flip_horizontal: false
-anti_alias: true
 fullscreen: false
 capture_mouse: false
-alpha_blend: true
 log_level_debug: false
 use_single_snapshot: true

--- a/tunnelclient/cfg/test.yaml
+++ b/tunnelclient/cfg/test.yaml
@@ -4,9 +4,7 @@ timesync_interval: 60000
 x_resolution: 960
 y_resolution: 540
 flip_horizontal: false
-anti_alias: true
 fullscreen: false
 capture_mouse: false
-alpha_blend: true
 log_level_debug: false
 use_single_snapshot: true

--- a/tunnelclient/cfg/test.yaml
+++ b/tunnelclient/cfg/test.yaml
@@ -9,3 +9,4 @@ fullscreen: false
 capture_mouse: false
 alpha_blend: true
 log_level_debug: false
+use_single_snapshot: true

--- a/tunnelclient/src/config.rs
+++ b/tunnelclient/src/config.rs
@@ -9,6 +9,12 @@ use std::time::Duration;
 use yaml_rust::YamlLoader;
 
 #[derive(Debug, Serialize, Deserialize)]
+pub enum SnapshotManagement {
+    VecDeque,
+    Single,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ClientConfig {
     /// Hostname of the machine running the controller.
     pub server_hostname: String,
@@ -16,6 +22,8 @@ pub struct ClientConfig {
     pub video_channel: u64,
     /// Delay between current time and time to render.
     pub render_delay: Duration,
+    /// Which snapshot management mechanism to use.
+    pub snapshot_management: SnapshotManagement,
     /// Delay between host/client time synchronization updates.
     pub timesync_interval: Duration,
     pub x_resolution: u32,
@@ -57,6 +65,7 @@ impl ClientConfig {
         capture_mouse: bool,
         transformation: Option<Transform>,
         log_level_debug: bool,
+        use_single_snapshot: bool,
     ) -> ClientConfig {
         let (x_resolution, y_resolution) = resolution;
 
@@ -77,6 +86,11 @@ impl ClientConfig {
             alpha_blend,
             transformation,
             log_level_debug,
+            snapshot_management: if use_single_snapshot {
+                SnapshotManagement::Single
+            } else {
+                SnapshotManagement::VecDeque
+            },
         }
     }
 
@@ -132,6 +146,7 @@ impl ClientConfig {
             flag("capture_mouse", "Bad mouse capture flag.")?,
             transformation,
             flag("log_level_debug", "Bad log level flag.")?,
+            flag("use_single_snapshot", "Bad use single snapshot flag.")?,
         ))
     }
 }

--- a/tunnelclient/src/config.rs
+++ b/tunnelclient/src/config.rs
@@ -10,7 +10,9 @@ use yaml_rust::YamlLoader;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum SnapshotManagement {
-    VecDeque,
+    /// Store a queue of snapshots and choose between them, with a render delay.
+    Queued,
+    /// Always render the latest snapshot.
     Single,
 }
 
@@ -28,10 +30,6 @@ pub struct ClientConfig {
     pub timesync_interval: Duration,
     pub x_resolution: u32,
     pub y_resolution: u32,
-    /// If true, perform anti-aliasing.  Adds a small additional GPU load.
-    pub anti_alias: bool,
-    /// If true, use alpha-blending rather than stomping underlying beams.
-    pub alpha_blend: bool,
     /// If true, set the window to fullscreen on creation.
     pub fullscreen: bool,
     /// If true, capture and hide the cursor.
@@ -59,9 +57,7 @@ impl ClientConfig {
         resolution: Resolution,
         timesync_interval: Duration,
         render_delay: Duration,
-        anti_alias: bool,
         fullscreen: bool,
-        alpha_blend: bool,
         capture_mouse: bool,
         transformation: Option<Transform>,
         log_level_debug: bool,
@@ -76,20 +72,18 @@ impl ClientConfig {
             timesync_interval,
             x_resolution,
             y_resolution,
-            anti_alias,
             fullscreen,
             capture_mouse,
             critical_size: f64::from(cmp::min(x_resolution, y_resolution)),
             thickness_scale: 0.5,
             x_center: f64::from(x_resolution / 2),
             y_center: f64::from(y_resolution / 2),
-            alpha_blend,
             transformation,
             log_level_debug,
             snapshot_management: if use_single_snapshot {
                 SnapshotManagement::Single
             } else {
-                SnapshotManagement::VecDeque
+                SnapshotManagement::Queued
             },
         }
     }
@@ -140,9 +134,7 @@ impl ClientConfig {
                     .as_f64()
                     .ok_or(anyhow!("Bad render delay."))?,
             ),
-            flag("anti_alias", "Bad anti-alias flag.")?,
             flag("fullscreen", "Bad fullscreen flag.")?,
-            flag("alpha_blend", "Bad alpha blend flag.")?,
             flag("capture_mouse", "Bad mouse capture flag.")?,
             transformation,
             flag("log_level_debug", "Bad log level flag.")?,

--- a/tunnelclient/src/draw.rs
+++ b/tunnelclient/src/draw.rs
@@ -85,13 +85,7 @@ impl<G: Graphics> Draw<G> for ArcSegment {
     fn draw(&self, c: &Context, gl: &mut G, cfg: &ClientConfig) {
         let thickness = self.thickness * cfg.critical_size * cfg.thickness_scale / 2.0;
 
-        let (val, alpha) = if cfg.alpha_blend {
-            (self.val, self.level)
-        } else {
-            (self.val * self.level, 1.0)
-        };
-
-        let color = hsv_to_rgb(self.hue, self.sat, val, alpha);
+        let color = hsv_to_rgb(self.hue, self.sat, self.val, self.level);
 
         let (x, y) = {
             let (x0, y0) = match cfg.transformation {

--- a/tunnelclient/src/remote.rs
+++ b/tunnelclient/src/remote.rs
@@ -275,6 +275,7 @@ where
     let mut render_delay = 0.015;
     let mut alpha_blend = true;
     let mut capture_mouse = true;
+    let mut single_snapshot = false;
 
     if prompt_y_n("Configure advanced settings") {
         capture_mouse = prompt_y_n("Capture mouse");
@@ -286,6 +287,7 @@ where
         );
         timesync_interval = Duration::from_secs(timesync_interval_secs);
         render_delay = prompt("Client render delay in seconds (default 0.015)", parse_f64);
+        single_snapshot = prompt_y_n("Use single snapshot mode");
     }
 
     ClientConfig::new(
@@ -300,6 +302,7 @@ where
         capture_mouse,
         transformation,
         false,
+        single_snapshot,
     )
 }
 

--- a/tunnelclient/src/remote.rs
+++ b/tunnelclient/src/remote.rs
@@ -270,17 +270,13 @@ where
     };
 
     // Some defaults we might configure in advanced mode.
-    let mut anti_alias = true;
     let mut timesync_interval = Duration::from_secs(60);
     let mut render_delay = 0.015;
-    let mut alpha_blend = true;
     let mut capture_mouse = true;
     let mut single_snapshot = false;
 
     if prompt_y_n("Configure advanced settings") {
         capture_mouse = prompt_y_n("Capture mouse");
-        anti_alias = prompt_y_n("Use anti-aliasing");
-        alpha_blend = prompt_y_n("Use alpha channel blending");
         let timesync_interval_secs = prompt(
             "Host/client time resynchronization interval in seconds (default 60)",
             parse_uint,
@@ -296,9 +292,7 @@ where
         resolution,
         timesync_interval,
         Duration::from_secs_f64(render_delay),
-        anti_alias,
         fullscreen,
-        alpha_blend,
         capture_mouse,
         transformation,
         false,

--- a/tunnelclient/src/remote.rs
+++ b/tunnelclient/src/remote.rs
@@ -273,7 +273,7 @@ where
     let mut timesync_interval = Duration::from_secs(60);
     let mut render_delay = 0.015;
     let mut capture_mouse = true;
-    let mut single_snapshot = false;
+    let mut single_snapshot = true;
 
     if prompt_y_n("Configure advanced settings") {
         capture_mouse = prompt_y_n("Capture mouse");

--- a/tunnelclient/src/show.rs
+++ b/tunnelclient/src/show.rs
@@ -3,7 +3,7 @@ use crate::config::SnapshotManagement;
 use crate::draw::Draw;
 use crate::snapshot_manager::SingleSnapshotManager;
 use crate::snapshot_manager::SnapshotFetchResult;
-use crate::snapshot_manager::SnapshotFetchResult::*;
+
 use crate::snapshot_manager::SnapshotManager;
 use crate::snapshot_manager::SnapshotManagerHandle;
 use crate::snapshot_manager::VecDequeSnapshotManager;
@@ -11,7 +11,7 @@ use crate::timesync::SynchronizerHandle;
 use crate::timesync::{Client as TimesyncClient, Synchronizer};
 use anyhow::{anyhow, Context as ErrorContext, Result};
 use graphics::clear;
-use log::{debug, error, info, max_level, warn, Level};
+use log::{debug, error, info, warn};
 use opengl_graphics::{GlGraphics, OpenGL};
 use piston_window::*;
 use sdl2_window::Sdl2Window;
@@ -312,7 +312,7 @@ fn receive_snapshots(
     ctx: &Context,
     cfg: &ClientConfig,
     snapshot_manager: SnapshotManagerHandle,
-    timesync: SynchronizerHandle,
+    _timesync: SynchronizerHandle,
     run_flag: RunFlag,
 ) -> Result<()> {
     let mut receiver: Receiver<Snapshot> = Receiver::new(

--- a/tunnelclient/src/show.rs
+++ b/tunnelclient/src/show.rs
@@ -98,6 +98,12 @@ impl Show {
         .map_err(|err| anyhow!("{err}"))?;
 
         window.set_capture_cursor(cfg.capture_mouse);
+        // This has no effect if vsync is properly enabled, but on machines with
+        // broken vsync this does work to make rendering a lot smoother.
+        // Note that with vsync enabled, this causes Piston to send incorrect
+        // timesteps to update args; since we only use this for interpolating
+        // timesync, it isn't a big deal.
+        window.set_max_fps(120);
 
         Ok(Show {
             gl: GlGraphics::new(opengl),

--- a/tunnelclient/src/show.rs
+++ b/tunnelclient/src/show.rs
@@ -10,6 +10,7 @@ use crate::snapshot_manager::VecDequeSnapshotManager;
 use crate::timesync::SynchronizerHandle;
 use crate::timesync::{Client as TimesyncClient, Synchronizer};
 use anyhow::{anyhow, Context as ErrorContext, Result};
+use glfw_window::GlfwWindow;
 use graphics::clear;
 use log::{debug, error, info, max_level, warn, Level};
 use opengl_graphics::{GlGraphics, OpenGL};
@@ -32,7 +33,7 @@ pub struct Show {
     timesync: SynchronizerHandle,
     cfg: ClientConfig,
     run_flag: RunFlag,
-    window: PistonWindow<Sdl2Window>,
+    window: PistonWindow<GlfwWindow>,
     render_reporter: RenderIssueLogger,
 }
 
@@ -85,7 +86,7 @@ impl Show {
         thread::sleep(cfg.render_delay);
 
         // Create the window.
-        let mut window: PistonWindow<Sdl2Window> = WindowSettings::new(
+        let mut window: PistonWindow<GlfwWindow> = WindowSettings::new(
             format!("tunnelclient: channel {}", cfg.video_channel),
             [cfg.x_resolution, cfg.y_resolution],
         )
@@ -98,7 +99,7 @@ impl Show {
         .map_err(|err| anyhow!("{err}"))?;
 
         window.set_capture_cursor(cfg.capture_mouse);
-        window.set_max_fps(120);
+        window.window.window.maximize();
 
         Ok(Show {
             gl: GlGraphics::new(opengl),
@@ -332,7 +333,7 @@ fn receive_snapshots(
                 }
                 match receiver.receive_msg(true) {
                     Ok(Some(msg)) => {
-                        // info!(
+                        // println!(
                         //     "receive latency: {}",
                         //     timesync.lock().unwrap().now() - msg.time
                         // );

--- a/tunnelclient/src/show.rs
+++ b/tunnelclient/src/show.rs
@@ -10,7 +10,6 @@ use crate::snapshot_manager::VecDequeSnapshotManager;
 use crate::timesync::SynchronizerHandle;
 use crate::timesync::{Client as TimesyncClient, Synchronizer};
 use anyhow::{anyhow, Context as ErrorContext, Result};
-use glfw_window::GlfwWindow;
 use graphics::clear;
 use log::{debug, error, info, max_level, warn, Level};
 use opengl_graphics::{GlGraphics, OpenGL};
@@ -33,7 +32,7 @@ pub struct Show {
     timesync: SynchronizerHandle,
     cfg: ClientConfig,
     run_flag: RunFlag,
-    window: PistonWindow<GlfwWindow>,
+    window: PistonWindow<Sdl2Window>,
     render_reporter: RenderIssueLogger,
 }
 
@@ -86,7 +85,7 @@ impl Show {
         thread::sleep(cfg.render_delay);
 
         // Create the window.
-        let mut window: PistonWindow<GlfwWindow> = WindowSettings::new(
+        let mut window: PistonWindow<Sdl2Window> = WindowSettings::new(
             format!("tunnelclient: channel {}", cfg.video_channel),
             [cfg.x_resolution, cfg.y_resolution],
         )
@@ -99,7 +98,6 @@ impl Show {
         .map_err(|err| anyhow!("{err}"))?;
 
         window.set_capture_cursor(cfg.capture_mouse);
-        window.window.window.maximize();
 
         Ok(Show {
             gl: GlGraphics::new(opengl),

--- a/tunnelclient/src/show.rs
+++ b/tunnelclient/src/show.rs
@@ -64,7 +64,7 @@ impl Show {
 
         // Set up snapshot reception and management.
         let snapshot_manager = Arc::new(Mutex::new(match cfg.snapshot_management {
-            SnapshotManagement::VecDeque => {
+            SnapshotManagement::Queued => {
                 Box::<VecDequeSnapshotManager>::default() as Box<dyn SnapshotManager>
             }
             SnapshotManagement::Single => {
@@ -92,7 +92,7 @@ impl Show {
         .graphics_api(opengl)
         .exit_on_esc(true)
         .vsync(true)
-        .samples(if cfg.anti_alias { 4 } else { 0 })
+        .samples(4)
         .fullscreen(cfg.fullscreen)
         .build()
         .map_err(|err| anyhow!("{err}"))?;

--- a/tunnelclient/src/snapshot_manager.rs
+++ b/tunnelclient/src/snapshot_manager.rs
@@ -24,6 +24,17 @@ pub enum SnapshotFetchResult {
     Error(Vec<Snapshot>),          // Something went wrong and we couldn't perform interpolation.
 }
 
+impl SnapshotFetchResult {
+    pub fn frame(&self) -> Option<&LayerCollection> {
+        match self {
+            Self::Good(frame) | Self::MissingNewer(frame) | Self::MissingOlder(frame) => {
+                Some(frame)
+            }
+            _ => None,
+        }
+    }
+}
+
 enum InsertStrategy {
     PushFront,
     Insert,
@@ -75,6 +86,11 @@ impl SnapshotManager {
     /// Drop stale snapshots from the collection.
     pub fn update(&mut self) {
         self.drop_stale_snapshots();
+    }
+
+    /// Peek at the front snapshot, if there is one.
+    pub fn peek_front(&self) -> Option<&Snapshot> {
+        self.snapshots.front()
     }
 
     /// Given a timestamp, select the most relevant snapshot.

--- a/tunnels/src/bin/bin.rs
+++ b/tunnels/src/bin/bin.rs
@@ -70,7 +70,7 @@ fn main() -> Result<()> {
         show.load(&load_path)?;
     }
 
-    show.run(Duration::from_micros(16667))
+    show.run(Duration::from_nanos(16666667 / 4))
 }
 
 /// Prompt the user to optionally configure a test mode.

--- a/tunnels/src/bin/bin.rs
+++ b/tunnels/src/bin/bin.rs
@@ -17,6 +17,10 @@ use tunnels_lib::prompt::prompt_bool;
 use tunnels_lib::prompt::prompt_port;
 use tunnels_lib::prompt::read_string;
 
+/// This is approximately 240 fps, implying a worst-case client render latency of
+/// essentially this value.
+const RENDER_INTERVAL: Duration = Duration::from_nanos(16666667 / 4);
+
 fn main() -> Result<()> {
     SimpleLogger::init(LevelFilter::Info, LogConfig::default())?;
     let (inputs, outputs) = list_ports()?;
@@ -70,7 +74,7 @@ fn main() -> Result<()> {
         show.load(&load_path)?;
     }
 
-    show.run(Duration::from_nanos(16666667 / 4))
+    show.run(RENDER_INTERVAL)
 }
 
 /// Prompt the user to optionally configure a test mode.

--- a/tunnels/src/show.rs
+++ b/tunnels/src/show.rs
@@ -1,5 +1,4 @@
 use anyhow::{bail, Result};
-use core::time;
 use log::{self, error, info, warn};
 use rmp_serde::{Deserializer, Serializer};
 use serde::{Deserialize, Serialize};

--- a/tunnels_lib/src/lib.rs
+++ b/tunnels_lib/src/lib.rs
@@ -51,11 +51,6 @@ impl Timestamp {
     pub fn from_duration(d: Duration) -> Self {
         Self(d.as_micros() as i64)
     }
-
-    // Step mutably increments this timestamp by the provided step.
-    pub fn step(&mut self, step: Duration) {
-        *self += Self::from_duration(step);
-    }
 }
 
 impl num_traits::cast::ToPrimitive for Timestamp {

--- a/tunnels_lib/src/lib.rs
+++ b/tunnels_lib/src/lib.rs
@@ -5,7 +5,7 @@ pub mod number;
 pub mod prompt;
 pub mod smooth;
 
-use derive_more::{Add, Display, Div, Mul, Sub};
+use derive_more::{Add, AddAssign, Display, Div, Mul, Sub};
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -37,6 +37,7 @@ use std::{
     Mul,
     Div,
     Ord,
+    AddAssign,
     PartialOrd,
     Default,
 )]
@@ -53,7 +54,7 @@ impl Timestamp {
 
     // Step mutably increments this timestamp by the provided step.
     pub fn step(&mut self, step: Duration) {
-        *self = *self + Self::from_duration(step);
+        *self += Self::from_duration(step);
     }
 }
 


### PR DESCRIPTION
- Add improved render issue reporting with latency measurements.
- Fix a critical bug in timestamp generation that has always caused the timestamp to lag the current time by a constantly-growing amount.
- Overhaul snapshot management to make storing and using a single snapshot the default behavior. With accurate latency measurements and fixed timestamps, our render latency at the remote client is on the order of 1ms, so there's basically no reason to ever use anything but the most recent snapshot.
- Run the controller at 240 fps.  This quadruples the update rate, which drops the worst-case latency when rendering the host to ~5 ms, which also ensures that single snapshot management provides smooth results.