### PR TITLE
audio overhaul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,33 +173,33 @@ dependencies = [
 
 [[package]]
 name = "audio-processor-analysis"
-version = "0.4.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3563c1a75627866e676def37fcbf922ea0c40937b4f4bdc50c6a65676a7f81fa"
+checksum = "e890b9a0c7d44cf97784797675920e1bb43ad4c141e5a7c66a6731a1112fd765"
 dependencies = [
  "audio-garbage-collector",
  "audio-processor-traits",
  "log 0.4.22",
+ "numeric_literals",
  "rustfft",
 ]
 
 [[package]]
 name = "audio-processor-traits"
-version = "2.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6752766e446d1beed651cc363ba74f3ff920cee388c83e71eea1b3b11fcffc3"
+checksum = "ba17273641e8292f066357a76ed37a431f470874e862cda6d342b69eba50daa8"
 dependencies = [
  "audio-garbage-collector",
  "augmented-atomics",
  "num",
- "vst",
 ]
 
 [[package]]
 name = "augmented-atomics"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d1a11afb9994191da60619a1471f355a3004a354bd4bab0317292baffaa886"
+checksum = "c4941ce52e49a1241039b8551f1c191e36667a2c6680208bccb6f4e4fa3634ee"
 dependencies = [
  "num-traits",
  "serde",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "augmented-dsp-filters"
-version = "1.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5092a998a1dd7c03fba23ecc005147a465f85ebe7963772b82960eadda28b93b"
+checksum = "510993d8f1a334fef32da30c5d93992c1bb39938b8f21db232d34db0fca6e5ce"
 dependencies = [
  "audio-processor-traits",
  "num",
@@ -1358,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1979,6 +1979,16 @@ dependencies = [
  "derive_more",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "numeric_literals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "095aa67b0b9f2081746998f4f17106bdb51d56dc8c211afca5531b92b83bf98a"
+dependencies = [
+ "quote 1.0.37",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3501,20 +3511,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vst"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111c58168c9208a20c3f5cedeca0721aee2cac0e92c5ec2a16dc4beb5886a40a"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "libloading 0.7.4",
- "log 0.4.22",
- "num-traits",
- "num_enum 0.5.11",
-]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,24 +229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47611e530cf21bb89fbfe322aa8b1feae1ace33ff65f8ebf40fe3b4b99b7c9a2"
 
 [[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.6.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2 1.0.89",
- "quote 1.0.37",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.85",
-]
-
-[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,7 +262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd9e63c1744f755c2f60332b88de39d341e5e86239014ad839bd71c106dec42"
 dependencies = [
  "block-sys",
- "objc2-encode",
+ "objc2-encode 2.0.0-pre.2",
 ]
 
 [[package]]
@@ -349,15 +331,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-expr"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,17 +379,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading 0.8.5",
 ]
 
 [[package]]
@@ -538,22 +500,16 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.11.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
-]
-
-[[package]]
-name = "coreaudio-sys"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce857aa0b77d77287acc1ac3e37a05a8c95a2af3647d23b15f263bdaeb7562b"
-dependencies = [
- "bindgen",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -578,21 +534,24 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
 dependencies = [
  "alsa 0.9.1",
- "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni",
  "js-sys",
  "libc",
  "mach2",
- "ndk 0.8.0",
+ "ndk 0.9.0",
  "ndk-context",
- "oboe",
+ "num-derive",
+ "num-traits",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -783,6 +742,16 @@ name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.6.0",
+ "objc2 0.6.1",
+]
 
 [[package]]
 name = "dlib"
@@ -1194,12 +1163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "glutin"
 version = "0.30.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,7 +1177,7 @@ dependencies = [
  "glutin_glx_sys",
  "glutin_wgl_sys",
  "libloading 0.7.4",
- "objc2",
+ "objc2 0.3.0-beta.3.patch-leaks.3",
  "once_cell",
  "raw-window-handle",
  "wayland-sys 0.30.1",
@@ -1398,15 +1361,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1752,14 +1706,14 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.6.0",
  "jni-sys",
  "log 0.4.22",
- "ndk-sys 0.5.0+25.2.9519653",
+ "ndk-sys 0.6.0+11769913",
  "num_enum 0.7.3",
  "thiserror",
 ]
@@ -1781,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
+version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
 ]
@@ -2041,7 +1995,64 @@ checksum = "7e01640f9f2cb1220bbe80325e179e532cb3379ebcd1bf2279d703c19fe3a468"
 dependencies = [
  "block2",
  "objc-sys",
- "objc2-encode",
+ "objc2-encode 2.0.0-pre.2",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
+dependencies = [
+ "objc2-encode 4.1.0",
+]
+
+[[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cbe18d879e20a4aea544f8befe38bcf52255eb63d3f23eca2842f3319e4c07"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "objc2 0.6.1",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca44961e888e19313b808f23497073e3f6b3c22bb485056674c8b49f3b025c82"
+dependencies = [
+ "dispatch2",
+ "objc2 0.6.1",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f1cc99bb07ad2ddb6527ddf83db6a15271bb036b3eb94b801cd44fdc666ee1"
+dependencies = [
+ "bitflags 2.6.0",
+ "objc2 0.6.1",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.6.0",
+ "dispatch2",
+ "objc2 0.6.1",
 ]
 
 [[package]]
@@ -2054,26 +2065,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "oboe"
-version = "0.6.1"
+name = "objc2-encode"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
-dependencies = [
- "jni",
- "ndk 0.8.0",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
-]
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
-name = "oboe-sys"
-version = "0.6.1"
+name = "objc2-foundation"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
- "cc",
+ "objc2 0.6.1",
 ]
 
 [[package]]
@@ -2667,12 +2670,6 @@ dependencies = [
  "byteorder",
  "nom",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -3421,7 +3418,7 @@ dependencies = [
  "cpal",
  "derive_more",
  "insta",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "log 0.4.22",
  "midir",
@@ -4043,7 +4040,7 @@ dependencies = [
  "log 0.4.22",
  "mio 0.8.11",
  "ndk 0.7.0",
- "objc2",
+ "objc2 0.3.0-beta.3.patch-leaks.3",
  "once_cell",
  "orbclient",
  "percent-encoding",

--- a/tunnels/Cargo.toml
+++ b/tunnels/Cargo.toml
@@ -33,7 +33,7 @@ tunnels_lib = { path = "../tunnels_lib" }
 zero_configure = { path = "../zero_configure" }
 
 # Audio subsystem
-cpal = "0.15.1"
+cpal = "0.16"
 augmented-dsp-filters = "1.3.1"
 audio-processor-analysis = "0.4.0"
 audio-processor-traits = "2.2.0"

--- a/tunnels/Cargo.toml
+++ b/tunnels/Cargo.toml
@@ -26,20 +26,20 @@ rmp-serde.workspace = true
 
 midir = "0.9.1"
 rosc = "0.9.1"
+noise = "0.9.0"
 
 typed_index_derive = "0.1.4"
+itertools = "0.14"
 
 tunnels_lib = { path = "../tunnels_lib" }
 zero_configure = { path = "../zero_configure" }
 
 # Audio subsystem
 cpal = "0.16"
-augmented-dsp-filters = "1.3.1"
-audio-processor-analysis = "0.4.0"
-audio-processor-traits = "2.2.0"
-augmented-atomics = "0.1.1"
-itertools = "0.10.5"
-noise = "0.9.0"
+augmented-dsp-filters = "2"
+audio-processor-analysis = "2"
+audio-processor-traits = "4"
+augmented-atomics = "0.2"
 
 
 [dev-dependencies]

--- a/tunnels/src/audio/processor.rs
+++ b/tunnels/src/audio/processor.rs
@@ -1,9 +1,10 @@
 //! A multi-channel audio processor that derives a single envelope from its input.
 //! Provides lowpass filterting and configurable amplitude envelope.
 use audio_processor_analysis::envelope_follower_processor::EnvelopeFollowerProcessor;
-use audio_processor_traits::{AtomicF32, AudioProcessorSettings, SimpleAudioProcessor};
+use audio_processor_traits::AudioProcessorSettings;
+use audio_processor_traits::{simple_processor::MonoAudioProcessor, AtomicF32, AudioContext};
 use augmented_dsp_filters::rbj::{FilterProcessor, FilterType};
-use log::{debug, warn};
+use log::debug;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -48,18 +49,51 @@ pub struct Processor {
     channel_count: usize,
     filters: Vec<FilterProcessor<f32>>,
     envelopes: Vec<EnvelopeFollowerProcessor>,
+    context: AudioContext,
 }
 
 impl Processor {
-    pub fn new(handle: ProcessorSettings) -> Self {
+    pub fn new(handle: ProcessorSettings, sample_rate: u32, channel_count: usize) -> Self {
+        let mut context: AudioContext = AudioProcessorSettings {
+            sample_rate: sample_rate as f32,
+            input_channels: channel_count,
+            output_channels: channel_count, // unused
+            ..Default::default()
+        }
+        .into();
+        let settings = context.settings;
+
+        let mut filters = vec![];
+        let mut envelopes = vec![];
+
+        let filter_cutoff = handle.filter_cutoff.get();
+        let envelope_attack = handle.envelope_attack.get();
+        let envelope_release = handle.envelope_release.get();
+
+        for _ in 0..settings.input_channels {
+            let mut filter = FilterProcessor::new(FilterType::LowPass);
+            filter.set_cutoff(filter_cutoff);
+            filter.m_prepare(&mut context);
+            filters.push(filter);
+
+            let mut envelope = EnvelopeFollowerProcessor::new(
+                Duration::from_secs_f32(envelope_attack),
+                Duration::from_secs_f32(envelope_release),
+            );
+            envelope.m_prepare(&mut context);
+
+            envelopes.push(envelope);
+        }
+
         Self {
-            filter_cutoff: handle.filter_cutoff.get(),
-            envelope_attack: handle.envelope_attack.get(),
-            envelope_release: handle.envelope_release.get(),
+            filter_cutoff,
+            envelope_attack,
+            envelope_release,
             settings: handle,
-            channel_count: 0,
-            filters: Vec::new(),
-            envelopes: Vec::new(),
+            channel_count: settings.input_channels,
+            filters,
+            envelopes,
+            context,
         }
     }
 
@@ -95,55 +129,21 @@ impl Processor {
     }
 }
 
-impl SimpleAudioProcessor for Processor {
-    type SampleType = f32;
-    /// Prepare for playback based on current audio settings
-    fn s_prepare(&mut self, settings: AudioProcessorSettings) {
-        self.channel_count = settings.input_channels;
-        self.filters.clear();
-        self.envelopes.clear();
-        for _ in 0..settings.input_channels {
-            let mut filter = FilterProcessor::new(FilterType::LowPass);
-            filter.set_cutoff(self.filter_cutoff);
-            filter.s_prepare(settings);
-            self.filters.push(filter);
-
-            let mut envelope = EnvelopeFollowerProcessor::new(
-                Duration::from_secs_f32(self.envelope_attack),
-                Duration::from_secs_f32(self.envelope_release),
-            );
-            envelope.s_prepare(settings);
-
-            self.envelopes.push(envelope);
-        }
-    }
-
-    fn s_process(&mut self, _: Self::SampleType) -> Self::SampleType {
-        panic!("MultichannelProcessor must be called via s_process_frame.")
-    }
-
-    fn s_process_frame(&mut self, frame: &mut [Self::SampleType]) {
-        if frame.len() != self.channel_count {
-            warn!(
-                "Audio frame has size {} but processor is configured for {}.",
-                frame.len(),
-                self.channel_count
-            );
-        }
-
+impl Processor {
+    /// Process a buffer of interleaved audio data.
+    pub fn process(&mut self, interleaved_buffer: &[f32]) {
         self.maybe_update_parameters();
 
         // Average the envelopes together.
         let mut envelope_sum = 0.0;
 
-        // Manually call each inner processor using a slice of length 1, to
-        // work around the bizarre multichannel behavior of filters.
-        for chan in 0..frame.len() {
-            let single_channel_frame = &mut frame[chan..chan + 1];
-            self.filters[chan].s_process_frame(single_channel_frame);
-            let envelope = &mut self.envelopes[chan];
-            envelope.s_process_frame(single_channel_frame);
-            envelope_sum += envelope.handle().state();
+        for frame in interleaved_buffer.chunks(self.channel_count) {
+            for (channel_idx, sample) in frame.iter().enumerate() {
+                let sample = self.filters[channel_idx].m_process(&mut self.context, *sample);
+                let envelope = &mut self.envelopes[channel_idx];
+                envelope.m_process(&mut self.context, sample);
+                envelope_sum += envelope.handle().state();
+            }
         }
 
         self.settings

--- a/tunnels/src/audio/processor.rs
+++ b/tunnels/src/audio/processor.rs
@@ -6,7 +6,7 @@ use audio_processor_traits::{simple_processor::MonoAudioProcessor, AtomicF32, Au
 use augmented_dsp_filters::rbj::{FilterProcessor, FilterType};
 use log::debug;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 #[derive(Clone)]
 pub struct ProcessorSettingsInner {


### PR DESCRIPTION
- Update audio dependencies.
- Remove the augmented audio traits from our top-level processor interaction, and instead directly feed the interleaved buffer from cpal into our processor to avoid a bunch of unnecessary memcpy and other overhead.
- Dynamically size the requested audio input buffer size to target about 1 ms of audio latency or so.